### PR TITLE
Corrected start.sh echo output to improve clarity.

### DIFF
--- a/artik020/ota/app/start.sh
+++ b/artik020/ota/app/start.sh
@@ -1,11 +1,11 @@
-echo "Loading ftdi_sio module..."
+echo "Unloading ftdi_sio module..."
 modprobe -r ftdi_sio
-echo "Loaded FTDI module"
+echo "Unloaded FTDI module"
 sleep 3
 chmod +x ftdi.sh
-echo "openning screen terminal"
+echo "Opening screen terminal"
 screen -dmS ftdi_program  "./ftdi.sh"
-echo "opened screen terminal"
+echo "Opened screen terminal"
 sleep 5
 { sleep 5; echo "reset"; echo "program firmware/bootloader-storage-internal-ble-combined.s37"; echo "program firmware/soc-example.hex"; echo "reset"; sleep 10; } | telnet localhost 4444
 tail -f /dev/null


### PR DESCRIPTION
Corrected shell output to improve clarity about module unloading/loading operation. Loading this module is required for USB serial functionality between the FTDI 2232H and the Coprocessor.

Change-type: patch
Signed-off-by: Alex Bucknall <alex.bucknall@gmail.com>